### PR TITLE
change prompt_name for aggregate functions into search_query

### DIFF
--- a/src/include/flockmtl/core/functions/aggregate/llm_agg.hpp
+++ b/src/include/flockmtl/core/functions/aggregate/llm_agg.hpp
@@ -22,11 +22,11 @@ class LlmMinOrMax {
 public:
     std::string model;
     int model_context_size;
-    std::string user_prompt;
+    std::string search_query;
     std::string llm_min_or_max_template;
     int available_tokens;
 
-    LlmMinOrMax(std::string &model, int model_context_size, std::string &user_prompt,
+    LlmMinOrMax(std::string &model, int model_context_size, std::string &search_query,
                 std::string &llm_min_or_max_template);
 
     nlohmann::json GetMaxOrMinTupleId(const nlohmann::json &tuples);
@@ -38,7 +38,7 @@ private:
 
 struct LlmAggOperation {
     static std::string model_name;
-    static std::string prompt_name;
+    static std::string search_query;
     static std::unordered_map<void *, std::shared_ptr<LlmAggState>> state_map;
 
     static void Initialize(const AggregateFunction &, data_ptr_t state_p);

--- a/src/include/flockmtl/core/functions/aggregate/llm_rerank.hpp
+++ b/src/include/flockmtl/core/functions/aggregate/llm_rerank.hpp
@@ -14,7 +14,7 @@ public:
 private:
     std::string model;
     int model_context_size;
-    std::string user_prompt;
+    std::string search_query;
     std::string llm_reranking_template;
     int available_tokens;
 

--- a/src/include/templates/llm_min_or_max_prompt_template.hpp
+++ b/src/include/templates/llm_min_or_max_prompt_template.hpp
@@ -14,7 +14,7 @@ Tuples:
 [{{tuple.id}}] {{tuple.content}}
 {% endfor %}
 
-Search Query: {{user_prompt}}
+Search Query: {{search_query}}
 
 Select the **single {relevance} relevant tuple** from the tuples provided.The output format should be a JSON object. Only respond with the result, do not explain or add additional words.
 

--- a/src/include/templates/llm_rerank_prompt_template.hpp
+++ b/src/include/templates/llm_rerank_prompt_template.hpp
@@ -12,7 +12,7 @@ Tuples:
 [{{tuple.id}}] {{tuple.content}}
 {% endfor %}
 
-Search Query: {{user_prompt}}
+Search Query: {{search_query}}
 
 Rank the tuples above based on their relevance to the search query. All the passages should be included and listed using identifiers, in descending order of relevance. The output format should be in JSON list [id_1, ..., id_n], e.g., [22, 33, ..., 3], Only respond with the ranking results, do not say any word or explain.
 


### PR DESCRIPTION
This PR updates the query to improve clarity and flexibility in specifying prompt text for the `llm_min`, `llm_max` and `llm_reranking` function. 

### Changes:

**Old version:**
```sql
select col1, llm_min('<prompt_name>', 'default', {'input': input}) from table group by col2;
```

**New version:**
```sql
select col1, llm_min('<your search query here>', 'default', {'input': input}) from table group by col2;
```